### PR TITLE
ufw enable 命令需要在防火墙规则配置好之后才执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ sudo timedatectl set-timezone Asia/Shanghai
 
 使用如下命令设置，请根据自己的管理地址段，替换下面的`202.38.64.0/24`
 ```bash
-sudo ufw enable
 sudo ufw allow 80/tcp
 sudo ufw allow 443/tcp
 sudo ufw allow proto tcp from 202.38.64.0/24 to any port 22
 sudo ufw default deny
+sudo ufw enable
 ```
 您可以使用命令`sudo ufw status numbered`查看设置的规则，如果设置错误，可以使用`sudo ufw delete [序号]`删除规则。
 


### PR DESCRIPTION
否则 ufw enable 之后可能会导致当前的 SSH 连接中断，给配置带来了麻烦，因此在任何时候都推荐将初步的防火墙规则编写好之后再 enable